### PR TITLE
fix CI error saying xvfb failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
   - "10"
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 script:
   - npm run lint
   - npm run test-travis


### PR DESCRIPTION
> ```
> $ sh -e /etc/init.d/xvfb start
> sh: 0: Can't open /etc/init.d/xvfb
> The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
> ```

https://docs.travis-ci.com/user/gui-and-headless-browsers/